### PR TITLE
feat: Loosen iframe sandbox restrictions

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
         class="w-full h-full border-none"
         allow="camera; microphone; fullscreen"
         loading="lazy"
-        sandbox="allow-same-origin allow-scripts allow-camera allow-microphone allow-fullscreen"
+        sandbox="allow-same-origin allow-scripts allow-forms allow-popups allow-camera allow-microphone allow-fullscreen"
       >
         <p>Your browser does not support iframes.</p>
       </iframe>


### PR DESCRIPTION
- Updated the iframe sandbox attribute to be less restrictive to allow for saving bookmarks and viewing chat history.
- Added `allow-forms` and `allow-popups` to the sandbox attribute.